### PR TITLE
Fix go get link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Unicode transliterator (also known as unidecode) for Go
 
 Use the following command to install gounidecode
 
-go get http://github.com/fiam/gounidecode/unidecode
+go get github.com/fiam/gounidecode/unidecode
 
 Example usage
 =============


### PR DESCRIPTION
Otherwise on Go 1.2 and Windows

> go get -u -v http://github.com/fiam/gounidecode/unidecode
> import "http:/github.com/fiam/gounidecode/unidecode": import path doesn't contain a hostname
> package http:/github.com/fiam/gounidecode/unidecode: unrecognized import path "http:/github.com/fiam/gounidecode/unidecode"
